### PR TITLE
Assorted fixes/tweaks to Iterable/mParticle deep link handling

### DIFF
--- a/mParticle-iterable/IterableMPHelper.h
+++ b/mParticle-iterable/IterableMPHelper.h
@@ -13,6 +13,10 @@ typedef void (^ITEActionBlock)(NSString *);
 
 #define ITBL_DEEPLINK_IDENTIFIER @"/a/[a-zA-Z0-9]+"
 
+// Keys in the linkInfo passed to the -checkForDeferredDeepLinkWithCompletionHandler: handler
+extern NSString * _Nonnull const IterableDestinationURLKey;
+extern NSString * _Nonnull const IterableClickedURLKey;
+
 /**
  `IterableAPI` contains all the essential functions for communicating with Iterable's API
  */

--- a/mParticle-iterable/IterableMPHelper.m
+++ b/mParticle-iterable/IterableMPHelper.m
@@ -9,6 +9,8 @@
 #import <Foundation/Foundation.h>
 #import "IterableMPHelper.h"
 
+NSString *const IterableDestinationURLKey = @"IterableDestinationURLKey";
+NSString *const IterableClickedURLKey = @"IterableClickedURLKey";
 
 @interface IterableAPI () {
 }

--- a/mParticle-iterable/IterableMPHelper.m
+++ b/mParticle-iterable/IterableMPHelper.m
@@ -20,18 +20,14 @@
 
 +(void) getAndTrackDeeplink:(NSURL *)webpageURL callbackBlock:(ITEActionBlock)callbackBlock
 {
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:ITBL_DEEPLINK_IDENTIFIER options:0 error:NULL];
-    NSString *urlString = webpageURL.absoluteString;
-    NSTextCheckingResult *match = [regex firstMatchInString:urlString options:0 range:NSMakeRange(0, [urlString length])];
-    
-    if (match == NULL) {
-        callbackBlock(webpageURL.absoluteString);
-    } else {
+    if ([self isIterableDeeplink:webpageURL]) {
         NSURLSessionDataTask *trackAndRedirectTask = [[NSURLSession sharedSession]
                                                       dataTaskWithURL:webpageURL completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
                                                           callbackBlock(response.URL.absoluteString);
                                                       }];
         [trackAndRedirectTask resume];
+    } else {
+        callbackBlock(webpageURL.absoluteString);
     }
 }
 
@@ -41,6 +37,7 @@
     NSString *urlString = webpageURL.absoluteString;
     NSTextCheckingResult *match = [regex firstMatchInString:urlString options:0 range:NSMakeRange(0, [urlString length])];
     
-    return match;
+    return match != NULL;
+}
 
 @end

--- a/mParticle-iterable/MPKitIterable.m
+++ b/mParticle-iterable/MPKitIterable.m
@@ -18,9 +18,6 @@
 
 #import "MPKitIterable.h"
 
-NSString *const destinationDeeplinkURL = @"destinationURL";
-NSString *const clickedDeeplinkURL = @"clickedURL";
-
 @interface MPKitIterable() {
     NSDictionary *getAndTrackParams;
     void (^completionHandlerCopy)(NSDictionary *, NSError *);
@@ -93,9 +90,9 @@ NSString *const clickedDeeplinkURL = @"clickedURL";
      
      getAndTrackParams = nil;
      ITEActionBlock callbackBlock = ^(NSString* destinationURL) {
-         getAndTrackParams = [[NSDictionary alloc] initWithObjectsAndKeys: destinationURL, destinationDeeplinkURL, clickedURL, clickedDeeplinkURL, nil];
          completionHandlerCopy(getAndTrackParams, nil);
          completionHandlerCopy = nil;
+         getAndTrackParams = [[NSDictionary alloc] initWithObjectsAndKeys: destinationURL, IterableDestinationURLKey, clickedURL, IterableClickedURLKey, nil];
      };
      [IterableAPI getAndTrackDeeplink:clickedURL callbackBlock:callbackBlock];
 

--- a/mParticle-iterable/MPKitIterable.m
+++ b/mParticle-iterable/MPKitIterable.m
@@ -90,9 +90,11 @@
      
      getAndTrackParams = nil;
      ITEActionBlock callbackBlock = ^(NSString* destinationURL) {
-         completionHandlerCopy(getAndTrackParams, nil);
-         completionHandlerCopy = nil;
          getAndTrackParams = [[NSDictionary alloc] initWithObjectsAndKeys: destinationURL, IterableDestinationURLKey, clickedURL, IterableClickedURLKey, nil];
+         if (completionHandlerCopy) {
+             completionHandlerCopy(getAndTrackParams, nil);
+             completionHandlerCopy = nil;
+         }
      };
      [IterableAPI getAndTrackDeeplink:clickedURL callbackBlock:callbackBlock];
 


### PR DESCRIPTION
The individual commits describe each change. The most important is the third re the potential crash on a missing `completionHandlerCopy`, but the other two seem worth making. Thanks!

cc @davidtruong @samdozor